### PR TITLE
Update Lambda Function docs URL and pydantic dependency

### DIFF
--- a/cdk/stacks/cdk_lambda_fastapi_stack.py
+++ b/cdk/stacks/cdk_lambda_fastapi_stack.py
@@ -115,6 +115,6 @@ class LambdaFunctionFastAPIStack(Stack):
         CfnOutput(
             self,
             "LambdaFunctionDocsUrl",
-            value=self.lambda_function_url.url,
+            value=f"{self.lambda_function_url.url}docs",
             description="Documentation URL to invoke Lambda Function",
         )

--- a/lambda-layers/fastapi/requirements.txt
+++ b/lambda-layers/fastapi/requirements.txt
@@ -1,2 +1,4 @@
 fastapi==0.109.0
 mangum==0.17.0
+pydantic>=2.5.3
+pydantic_core>=2.14.6

--- a/src/lambdas/api/main.py
+++ b/src/lambdas/api/main.py
@@ -12,7 +12,7 @@ app = FastAPI(
     description="Simple FastAPI server that runs on top of Lambda Functions.",
     contact={"Santiago Garcia Arango": "san99tiago@gmail.com"},
     title="Simple FastAPI Example",
-    version="0.0.1",
+    version="1.0.0",
 )
 
 


### PR DESCRIPTION
- Updates on docs Lambda Function URL
- Add pydantic dependency to Lambda Layer for future-proof [Pydantic arch issue](https://stackoverflow.com/questions/76650856/no-module-named-pydantic-core-pydantic-core-in-aws-lambda-though-library-is-i)